### PR TITLE
Add support for reading Colors (Version 1) and 64-bit Version 2 SplinePaths

### DIFF
--- a/Source/SharpNeedle/SonicTeam/SplinePath.cs
+++ b/Source/SharpNeedle/SonicTeam/SplinePath.cs
@@ -104,24 +104,26 @@ public class SplinePath : BinaryResource
 
             foreach (var path in Paths)
             {
-                if (path.Name.Equals("StageGuidePath"))
+                if (path.Name.Equals("StageGuidePath", StringComparison.InvariantCulture))
                     continue;
 
-                if (!path.Name.Contains("@"))
+                if (path.Name.LastIndexOf('@') == -1)
                 {
                     paths[0].Add(path);
                 }
                 else
                 {
-                    string[] splits = path.Name.Split('@');
-                    if (splits[1].StartsWith("QS"))
+                    var type = path.Name.AsSpan(path.Name.LastIndexOf('@') + 1);
+                    if (type.StartsWith("QS", StringComparison.InvariantCulture))
                         paths[1].Add(path);
-                    else if (splits[1].StartsWith("SV"))
+                    else if (type.StartsWith("SV", StringComparison.InvariantCulture))
                         paths[2].Add(path);
-                    else if (splits[1].StartsWith("GR"))
+                    else if (type.StartsWith("GR", StringComparison.InvariantCulture))
                         paths[3].Add(path);
-                    if (splits[1].StartsWith("DP"))
+                    else if (type.StartsWith("DP", StringComparison.InvariantCulture))
                         paths[4].Add(path);
+                    else
+                        throw new NotImplementedException($"{type} is not recognized");
                 }
             }
 

--- a/Source/SharpNeedle/SonicTeam/SplinePath.cs
+++ b/Source/SharpNeedle/SonicTeam/SplinePath.cs
@@ -38,8 +38,6 @@ public class SplinePath : BinaryResource
         writer.Write(0x200); // Version?
 
         writer.Write(Paths.Count);
-       
-        writer.OffsetBinaryFormat = OffsetBinaryFormat.U64;
 
         if (writer.OffsetBinaryFormat == OffsetBinaryFormat.U64)
             writer.Align(8);
@@ -48,8 +46,6 @@ public class SplinePath : BinaryResource
             writer.WriteObjectCollectionOffset(Paths);
         else
             writer.WriteOffsetValue(0);
-
-        writer.OffsetBinaryFormat = OffsetBinaryFormat.U32;
     }
 }
 
@@ -125,8 +121,6 @@ public class PathObject : IBinarySerializable
 
     public void Write(BinaryObjectWriter writer)
     {
-        writer.OffsetBinaryFormat = OffsetBinaryFormat.U64;
-
         writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name);
         writer.Write(Field04);
         writer.Write((byte)0);
@@ -183,8 +177,6 @@ public class PathObject : IBinarySerializable
             writer.Align(8);
 
         writer.WriteObjectOffset(Unknown);
-
-        writer.OffsetBinaryFormat = OffsetBinaryFormat.U32;
     }
 
     public override string ToString()
@@ -246,8 +238,6 @@ public class PathObject : IBinarySerializable
 
         public void Write(BinaryObjectWriter writer)
         {
-            writer.OffsetBinaryFormat = OffsetBinaryFormat.U64;
-
             if (writer.OffsetBinaryFormat == OffsetBinaryFormat.U64)
                 writer.Align(8);
 
@@ -275,8 +265,6 @@ public class PathObject : IBinarySerializable
                 default:
                     throw new NotImplementedException($"{Type} is not recognized");
             }
-
-            writer.OffsetBinaryFormat = OffsetBinaryFormat.U32;
         }
 
         public override string ToString()
@@ -363,8 +351,6 @@ public class PathObject : IBinarySerializable
 
         public void Write(BinaryObjectWriter writer)
         {
-            writer.OffsetBinaryFormat = OffsetBinaryFormat.U64;
-
             writer.Write(Field00);
 
             writer.Write(SubUnknown1s.Count);
@@ -387,8 +373,6 @@ public class PathObject : IBinarySerializable
                 writer.Align(8);
 
             writer.WriteCollectionOffset(SubUnknown3s);
-
-            writer.OffsetBinaryFormat = OffsetBinaryFormat.U32;
         }
     }
 }


### PR DESCRIPTION
Added support for reading 64-bit versions of the SplinePath found in the likes of Sonic Forces and Sonic Frontiers.
64-bit writing is not yet supported as that requires modifications to the BinaryResource so that the BINA header can be written with different `OffsetBinaryFormat` than the rest of the data.